### PR TITLE
extract transports from data.response

### DIFF
--- a/lessons/using-webauthn/setting-up-endpoints.html
+++ b/lessons/using-webauthn/setting-up-endpoints.html
@@ -80,7 +80,7 @@ app.<span class="hljs-title function_">post</span>(<span class="hljs-string">&qu
           credentialPublicKey,
           credentialID,
           counter,
-          <span class="hljs-attr">transports</span>: data.<span class="hljs-property">transports</span>,
+          <span class="hljs-attr">transports</span>: data.<span class="hljs-property">response</span>.<span class="hljs-property">transports</span>,
         };
         <span class="hljs-keyword">if</span> (user.<span class="hljs-property">devices</span>==<span class="hljs-literal">undefined</span>) {
             user.<span class="hljs-property">devices</span> = [];


### PR DESCRIPTION
During the Frontend Masters course the copied code from https://firtman.github.io/authentication/lessons/using-webauthn/setting-up-endpoints wasn't adding the `transports` property to the user's devices, in what is saved to the database.

I am not sure when it changed, but the `transports` seem to now be nested under the `response` property in the `req.body.data`. 

I am submitting this PR to update that. Because students copy and paste the code, I don't think it would create any discontinuity with the course videos.